### PR TITLE
NCSD-1633: Adds current cosmos collections

### DIFF
--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -8,7 +8,7 @@
     "appServicePlanName": {
       "value": "__providerPortalAppServicePlan__"
     },
-    "appServicePlanResourceGroup": {
+    "sharedResourceGroup": {
       "value": "__providerPortalResourceGroup__"
     },
     "storageConnectionString": {
@@ -34,6 +34,9 @@
     },
     "cosmosDbKey": {
       "value": "__providerPortalCosmosDBPrimaryKey__"
+    },
+    "cosmosDbAccount": {
+      "value": "__providerPortalCosmosDBName__"
     },
     "cosmosDbDatabase": {
       "value": "__providerPortalCosmosDbAccDatabaseName__"
@@ -64,6 +67,24 @@
     },
     "referenceDataServiceApiKey": {
       "value": "__apimKey__"
+    },
+    "frameworkCollectionPartitionKey": {
+      "value": "__frameworkCollectionPartitionKey__"
+    },
+    "ProgTypeCollectionPartitionKey": {
+      "value": "__progtypeCollectionPartitionKey__"
+    },
+    "Tier1CollectionPartitionKey": {
+      "value": "__tier1sCollectionPartitionKey__"
+    },
+    "Tier2CollectionPartitionKey": {
+      "value": "__tier2sCollectionPartitionKey__"
+    },
+    "StandardsCollectionPartitionKey": {
+      "value": "__standardsCollectionPartitionKey__"
+    },
+    "StandardSectorCodeCollectionPartitionKey": {
+      "value": "__sectorcodesCollectionPartitionKey__"
     }
   }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -14,7 +14,7 @@
         "description": "App service plan to run the function app under"
       }
     },
-    "appServicePlanResourceGroup": {
+    "sharedResourceGroup": {
       "type": "string",
       "metadata": {
         "description": "Resource group the app service plan is in"
@@ -72,6 +72,12 @@
         "description": "Cosmos DB database name for app settings"
       }
     },
+    "cosmosDbAccount": {
+      "type": "string",
+      "metadata": {
+        "description": "Cosmos DB account name, used for creation of collections"
+      }
+    },
     "cosmosDbCollectionFeChoices": {
       "type": "string",
       "metadata": {
@@ -125,6 +131,42 @@
       "metadata": {
         "description": "Reference Data API service key"
       }
+    },
+    "frameworkCollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment..."
+      }
+    },
+    "ProgTypeCollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment."
+      }
+    },
+    "Tier1CollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment."
+      }
+    },
+    "Tier2CollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment."
+      }
+    },
+    "StandardsCollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment."
+      }
+    },
+    "StandardSectorCodeCollectionPartitionKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the partition key for this environment."
+      }
     }
   },
   "variables": {
@@ -174,7 +216,7 @@
             "value": "[parameters('appServicePlanName')]"
           },
           "appServicePlanResourceGroup": {
-            "value": "[parameters('appServicePlanResourceGroup')]"
+            "value": "[parameters('sharedResourceGroup')]"
           },
           "appServiceType": {
             "value": "functionapp"
@@ -302,7 +344,217 @@
           }
         }
       }
-    }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionFeChoices",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "fechoices"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "/UKPRN"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionFrameworks",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "frameworks"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('frameworkCollectionPartitionKey')]"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionProgTypes",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "progtypes"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('ProgTypeCollectionPartitionKey')]"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionTier1s",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "sectorsubjectareatier1s"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('Tier1CollectionPartitionKey')]"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionTier1s",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "sectorsubjectareatier2s"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('Tier2CollectionPartitionKey')]"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionStandards",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "standards"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('StandardsCollectionPartitionKey')]"
+                }
+            }
+        }
+    },
+    {
+        "apiVersion": "2017-05-10",
+        "name": "cosmosCollectionStandards",
+        "type": "Microsoft.Resources/deployments",
+        "resourceGroup": "[parameters('sharedResourceGroup')]",
+        "properties": {
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "accountName": {
+                    "value": "[parameters('cosmosDbAccount')]"
+                },
+                "databaseName": {
+                    "value": "[parameters('cosmosDBdatabase')]"
+                },
+                "collectionName": {
+                    "value": "standardsectorcodes"
+                },
+                "offerThroughput": {
+                    "value": 400
+                },
+                "partitionKey": {
+                    "value": "[parameters('StandardSectorCodeCollectionPartitionKey')]"
+                }
+            }
+        }
+      }
   ],
   "outputs": {
     "functionAppName": {

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -346,34 +346,34 @@
       }
     },
     {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionFeChoices",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionFeChoices",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
             },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "fechoices"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "/UKPRN"
-                }
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
+            },
+            "collectionName": {
+                "value": "fechoices"
+            },
+            "offerThroughput": {
+                "value": 400
+            },
+            "partitionKey": {
+                "value": "/UKPRN"
             }
         }
+      }
     },
     {
         "apiVersion": "2017-05-10",
@@ -381,180 +381,180 @@
         "type": "Microsoft.Resources/deployments",
         "resourceGroup": "[parameters('sharedResourceGroup')]",
         "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "frameworks"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('frameworkCollectionPartitionKey')]"
-                }
-            }
+          "mode": "Incremental",
+          "templateLink": {
+              "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+              "contentVersion": "1.0.0.0"
+          },
+          "parameters": {
+              "accountName": {
+                  "value": "[parameters('cosmosDbAccount')]"
+              },
+              "databaseName": {
+                  "value": "[parameters('cosmosDBdatabase')]"
+              },
+              "collectionName": {
+                  "value": "frameworks"
+              },
+              "offerThroughput": {
+                  "value": 400
+              },
+              "partitionKey": {
+                  "value": "[parameters('frameworkCollectionPartitionKey')]"
+              }
+          }
         }
     },
     {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionProgTypes",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionProgTypes",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
             },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "progtypes"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('ProgTypeCollectionPartitionKey')]"
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionTier1s",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
             },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "sectorsubjectareatier1s"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('Tier1CollectionPartitionKey')]"
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionTier1s",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
+            "collectionName": {
+                "value": "progtypes"
             },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "sectorsubjectareatier2s"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('Tier2CollectionPartitionKey')]"
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionStandards",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
+            "offerThroughput": {
+                "value": 400
             },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "standards"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('StandardsCollectionPartitionKey')]"
-                }
-            }
-        }
-    },
-    {
-        "apiVersion": "2017-05-10",
-        "name": "cosmosCollectionStandards",
-        "type": "Microsoft.Resources/deployments",
-        "resourceGroup": "[parameters('sharedResourceGroup')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
-                "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-                "accountName": {
-                    "value": "[parameters('cosmosDbAccount')]"
-                },
-                "databaseName": {
-                    "value": "[parameters('cosmosDBdatabase')]"
-                },
-                "collectionName": {
-                    "value": "standardsectorcodes"
-                },
-                "offerThroughput": {
-                    "value": 400
-                },
-                "partitionKey": {
-                    "value": "[parameters('StandardSectorCodeCollectionPartitionKey')]"
-                }
+            "partitionKey": {
+                "value": "[parameters('ProgTypeCollectionPartitionKey')]"
             }
         }
       }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionTier1s",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
+            },
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
+            },
+            "collectionName": {
+                "value": "sectorsubjectareatier1s"
+            },
+            "offerThroughput": {
+                "value": 400
+            },
+            "partitionKey": {
+                "value": "[parameters('Tier1CollectionPartitionKey')]"
+            }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionTier1s",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
+            },
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
+            },
+            "collectionName": {
+                "value": "sectorsubjectareatier2s"
+            },
+            "offerThroughput": {
+                "value": 400
+            },
+            "partitionKey": {
+                "value": "[parameters('Tier2CollectionPartitionKey')]"
+            }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionStandards",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
+            },
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
+            },
+            "collectionName": {
+                "value": "standards"
+            },
+            "offerThroughput": {
+                "value": 400
+            },
+            "partitionKey": {
+                "value": "[parameters('StandardsCollectionPartitionKey')]"
+            }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "cosmosCollectionStandards",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[parameters('sharedResourceGroup')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "[concat(variables('deploymentUrlBase'),'CosmosDb/cosmos-collection.json')]",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "accountName": {
+                "value": "[parameters('cosmosDbAccount')]"
+            },
+            "databaseName": {
+                "value": "[parameters('cosmosDBdatabase')]"
+            },
+            "collectionName": {
+                "value": "standardsectorcodes"
+            },
+            "offerThroughput": {
+                "value": 400
+            },
+            "partitionKey": {
+                "value": "[parameters('StandardSectorCodeCollectionPartitionKey')]"
+            }
+        }
+      }
+    }
   ],
   "outputs": {
     "functionAppName": {

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -527,7 +527,7 @@
     },
     {
       "apiVersion": "2017-05-10",
-      "name": "cosmosCollectionStandards",
+      "name": "cosmosCollectionStandardSectorCodes",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[parameters('sharedResourceGroup')]",
       "properties": {

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -467,7 +467,7 @@
     },
     {
       "apiVersion": "2017-05-10",
-      "name": "cosmosCollectionTier1s",
+      "name": "cosmosCollectionTier2s",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[parameters('sharedResourceGroup')]",
       "properties": {

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -32,6 +32,9 @@
     "cosmosDbKey": {
       "value": "not-a-real-key"
     },
+    "cosmosDbAccount": {
+      "value": "myCosmosAccount"
+    },
     "cosmosDbDatabase": {
       "value": "mydb"
     },

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -8,7 +8,7 @@
     "appServicePlanName": {
       "value": "dfc-dev-prov-asp"
     },
-    "appServicePlanResourceGroup": {
+    "sharedResourceGroup": {
       "value": "dfc-test-template-rg"
     },
     "storageConnectionString": {
@@ -61,6 +61,24 @@
     },
     "referenceDataServiceApiKey": {
       "value": "not-a-real-api-key"
+    },
+    "frameworkCollectionPartitionKey": {
+      "value": "a-partition-key"
+    },
+    "ProgTypeCollectionPartitionKey": {
+      "value": "a-partition-key"
+    },
+    "Tier1CollectionPartitionKey": {
+      "value": "a-partition-key"
+    },
+    "Tier2CollectionPartitionKey": {
+      "value": "a-partition-key"
+    },
+    "StandardsCollectionPartitionKey": {
+      "value": "a-partition-key"
+    },
+    "StandardSectorCodeCollectionPartitionKey": {
+      "value": "a-partition-key"
     }
   }
 }


### PR DESCRIPTION
Note: This is awful,  because for some reason, the partition key for most of the collecctions 'owned' by this service differs in dev to all other environments. 

This will need correcting going forward, but for now this PR documents the current configuration